### PR TITLE
Bump up version for eslint-plugin-prettier and @typescript-eslint/parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint": "^8.44.0",
         "eslint-plugin-github": "^4.8.0",
         "eslint-plugin-jest": "^27.2.2",
-        "eslint-plugin-prettier": "^5.0.0-alpha.2",
+        "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.6.1",
         "js-yaml": "^4.1.0",
         "prettier": "^3.0.0",
@@ -3441,9 +3441,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0-alpha.2.tgz",
-      "integrity": "sha512-F6YBCbrRzvZwcINw3crm1+/uX/i+rJYaFErPtwCfUoPLywRfY7pwBtI3yMe5OpIotuaiws8cd29oM80ca6NQSQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "dev": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
@@ -9825,9 +9825,9 @@
       "dev": true
     },
     "eslint-plugin-prettier": {
-      "version": "5.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0-alpha.2.tgz",
-      "integrity": "sha512-F6YBCbrRzvZwcINw3crm1+/uX/i+rJYaFErPtwCfUoPLywRfY7pwBtI3yMe5OpIotuaiws8cd29oM80ca6NQSQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8.44.0",
     "eslint-plugin-github": "^4.8.0",
     "eslint-plugin-jest": "^27.2.2",
-    "eslint-plugin-prettier": "^5.0.0-alpha.2",
+    "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.6.1",
     "js-yaml": "^4.1.0",
     "prettier": "^3.0.0",


### PR DESCRIPTION
update version:
eslint-plugin-prettier 5.0.0
@typescript-eslint/parser 5.62.0