### PR TITLE
add a comment on symlinkSync differences between GHA and azdo

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,7 @@ Read more about Azure Developer CLI telemetry: https://github.com/Azure/azure-de
       extracted = await toolCache.extractTar(file)
     }
 
+    // This keeps symlinkSync instead of copySync as setup-azd Azure DevOps for efficiency, storage space, etc.
     if (os !== 'win32') {
       fs.symlinkSync(
         path.join(extracted, installArray[1]),


### PR DESCRIPTION
We add a fix for [copySync](https://github.com/Azure/azure-dev/issues/4282) on azure devops. This comment points out the difference and why we want to keep it.