### PR TITLE
release 2.4.0 - harden azd version installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- [[566]](https://github.com/Azure/setup-azd/pull/566) Harden `azd` version installation. The `version` input is validated before use — accepted values are `latest`, `stable`, `daily`, or a semantic version such as `1.2.3`, `1.2.3-beta.1`, or `1.2.3+build.5` — and installer scripts are downloaded to an isolated temporary directory and invoked with explicit process arguments instead of a shell command line. Relates to Azure/azure-dev#9402.
+- [[566]](https://github.com/Azure/setup-azd/pull/566) Harden `azd` version installation. The `version` input is validated before use — accepted values are `latest`, `stable`, `daily`, or a semantic version such as `1.2.3`, `1.2.3-beta.1`, or `1.2.3+build.5` — and installer scripts are downloaded to an isolated temporary directory and invoked with explicit process arguments instead of a shell command line.
 
 ## 2.3.0 (2026-04-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Release History
 
+## 2.4.0 (2026-08-05)
+
+### Features Added
+
+- [[566]](https://github.com/Azure/setup-azd/pull/566) Validate the `version` input before installing. Accepted values are `latest`, `stable`, `daily`, or a semantic version such as `1.2.3`, `1.2.3-beta.1`, or `1.2.3+build.5`; anything else fails the action with a clear message instead of being passed to the installer.
+
+### Bugs Fixed
+
+- [[566]](https://github.com/Azure/setup-azd/pull/566) Surface installer failures reliably by preserving download, installation, and Windows version-check exit codes. Installer scripts are downloaded to an isolated temporary directory that is cleaned up afterwards, and cleanup failures are reported as warnings rather than failing the run.
+
+### Other Changes
+
+- [[566]](https://github.com/Azure/setup-azd/pull/566) Harden installation by invoking the installer scripts with explicit process arguments instead of interpolating the `version` input into a shell command line. Relates to Azure/azure-dev#9402.
+- Bump GitHub Actions versions used in workflows (`actions/checkout@v7`, `actions/setup-node@v7`) and dependency versions.
+
 ## 2.3.0 (2026-04-17)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,7 @@
 
 ### Features Added
 
-- [[566]](https://github.com/Azure/setup-azd/pull/566) Validate the `version` input before installing. Accepted values are `latest`, `stable`, `daily`, or a semantic version such as `1.2.3`, `1.2.3-beta.1`, or `1.2.3+build.5`; anything else fails the action with a clear message instead of being passed to the installer.
-
-### Bugs Fixed
-
-- [[566]](https://github.com/Azure/setup-azd/pull/566) Surface installer failures reliably by preserving download, installation, and Windows version-check exit codes. Installer scripts are downloaded to an isolated temporary directory that is cleaned up afterwards, and cleanup failures are reported as warnings rather than failing the run.
-
-### Other Changes
-
-- [[566]](https://github.com/Azure/setup-azd/pull/566) Harden installation by invoking the installer scripts with explicit process arguments instead of interpolating the `version` input into a shell command line. Relates to Azure/azure-dev#9402.
-- Bump GitHub Actions versions used in workflows (`actions/checkout@v7`, `actions/setup-node@v7`) and dependency versions.
+- [[566]](https://github.com/Azure/setup-azd/pull/566) Harden `azd` version installation. The `version` input is validated before use — accepted values are `latest`, `stable`, `daily`, or a semantic version such as `1.2.3`, `1.2.3-beta.1`, or `1.2.3+build.5` — and installer scripts are downloaded to an isolated temporary directory and invoked with explicit process arguments instead of a shell command line. Relates to Azure/azure-dev#9402.
 
 ## 2.3.0 (2026-04-17)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-azd",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-azd",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-azd",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": true,
   "type": "module",
   "description": "TypeScript template action",


### PR DESCRIPTION
## Summary

Version-bump PR for the **2.4.0** release. Contains release metadata only — no `src/` or `dist/` changes.

- `CHANGELOG.md` — prepend the `2.4.0 (2026-08-05)` section.
- `package.json` — bump `version` to `2.4.0`.
- `package-lock.json` — bump **both** `version` fields (top level and `packages.""`).

`dist/` is intentionally untouched: the only source change in this release (#566) already shipped its regenerated bundle to `main`. Verified with `git diff --ignore-space-at-eol dist/` (empty).

README `uses:` samples remain pinned to the floating major tag `@v2` per repo convention.

## Release contents

The release is a **minor** bump because #566 adds new input-validation behavior on top of the existing installer flow.

### Features Added

- [#566](https://github.com/Azure/setup-azd/pull/566) Validate the `version` input before installing. Accepted values are `latest`, `stable`, `daily`, or a semantic version such as `1.2.3`, `1.2.3-beta.1`, or `1.2.3+build.5`; anything else fails the action with a clear message instead of being passed to the installer.

### Bugs Fixed

- [#566](https://github.com/Azure/setup-azd/pull/566) Surface installer failures reliably by preserving download, installation, and Windows version-check exit codes. Installer scripts are downloaded to an isolated temporary directory that is cleaned up afterwards, and cleanup failures are reported as warnings rather than failing the run.

### Other Changes

- [#566](https://github.com/Azure/setup-azd/pull/566) Harden installation by invoking the installer scripts with explicit process arguments instead of interpolating the `version` input into a shell command line.
- Bump GitHub Actions versions used in workflows (`actions/checkout@v7`, `actions/setup-node@v7`) and dependency versions.

Relates to Azure/azure-dev#9402

## Validation

- Versions consistent across `CHANGELOG.md`, `package.json`, and both `package-lock.json` fields.
- `dist/` free of drift (`git diff --ignore-space-at-eol dist/` empty).
- README `uses:` samples still on `@v2`; embedded `action.yml` snippet still matches `action.yml` (`using: 'node24'`).

## Remaining release steps (after this merges)

Per [AGENTS.md § Release workflow](https://github.com/Azure/setup-azd/blob/main/AGENTS.md#release-workflow):

1. Pre-release smoke test a consumer pipeline on `Azure/setup-azd@main`.
2. Signed tag `v2.4.0` (`git tag -s`), then force-move the floating `v2` tag; confirm both show `verified: true`.
3. Draft the GitHub Release titled `setup-azd_v2.4.0` targeting `main`, paste the CHANGELOG entry, and check **Publish this Action to the GitHub Marketplace**.
4. Post-release validation on both `@v2.4.0` and `@v2`.
