### PR TITLE
build(deps-dev): bump js-yaml override to ^4.3.0 to fix GHSA-52cp-r559-cp3m

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1312,9 +1312,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "overrides": {
     "@babel/core": "^7.29.2",
     "@istanbuljs/load-nyc-config": {
-      "js-yaml": "^4.2.0"
+      "js-yaml": "^4.3.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes Dependabot alert [#68](https://github.com/Azure/setup-azd/security/dependabot/68) — [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) / CVE-2026-59869 (**high**, CVSS 7.5, CWE-400 / CWE-407): *js-yaml: YAML merge-key chains can force quadratic CPU consumption*.

The repo already carried an `overrides` entry pinning `js-yaml` for `@istanbuljs/load-nyc-config`, but it was set to `^4.2.0` — and 4.2.0 is exactly the vulnerable version. This raises the override to `^4.3.0`, the first patched release, so the transitive dev dependency now resolves to **4.3.1**.

```diff
   "overrides": {
     "@babel/core": "^7.29.2",
     "@istanbuljs/load-nyc-config": {
-      "js-yaml": "^4.2.0"
+      "js-yaml": "^4.3.0"
     }
   }
```

## Why the override is still needed

`@istanbuljs/load-nyc-config` requests `js-yaml@^3.13.1`, and the advisory covers `>= 3.0.0, < 3.15.0` as well as `>= 4.0.0, < 4.3.0`. Removing the override would resolve back into the affected 3.x line, so the pin stays — just moved onto a patched version.

## Scope and impact

- `js-yaml` here is a **transitive dev dependency** (jest → istanbul coverage tooling). It is not part of the action's runtime.
- The direct `js-yaml` devDependency is already on `^5.2.3` and was never affected.
- `dist/` is untouched — no `src/` change, verified with `git diff --ignore-space-at-eol dist/` (empty).

## Validation

- `npm ci` — clean install from the updated lockfile.
- `npm audit` — **found 0 vulnerabilities** (was 1 high).
- `npm run build` (`tsc`) — passes.
- `npx eslint "src/**/*.ts"` — clean.
- `npm test` — **36/36 Jest tests pass**, confirming the coverage tooling still loads correctly under the bumped override.
- `dist/` free of drift.
