### PR TITLE
ci: group npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- Group npm minor and patch updates into a single Dependabot pull request.
- Keep the existing daily update schedule.
- Retain the existing seven-day cooldown for npm and GitHub Actions updates.

Major npm updates remain separate, and security updates remain immediate.